### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "event-stream": "^3.1.2",
     "gulp-util": "^3.0.0",
-    "htmlencode": "0.0.4"
+    "htmlencode": "0.0.4",
+    "fs-extra": "^0.12.0",
+    "through": "^2.3.6"
   },
   "devDependencies": {
-    "fs-extra": "^0.12.0",
     "gulp-csslint": "^0.1.5",
     "mocha": "^1.18.2",
-    "should": "^3.3.1",
-    "through": "^2.3.6"
+    "should": "^3.3.1"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
`fs-extra` and `through` are actually `dependencies`.
